### PR TITLE
fix(README): remove non-programming languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,3 @@
 - 👀 I’m interested in sport, coding and design
 - 🌱 I can currently code in HTML, CSS, JavaScript and Java.
 - 📫 How to reach me I have an epic discord server! (https://cup.corasite.repl.it/discord)
-- 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 - 👀 I’m interested in sport, coding and design
 - 🌱 I can currently code in HTML, CSS, JavaScript and Java.
 - 📫 How to reach me I have an epic discord server! (https://cup.corasite.repl.it/discord)
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 - 👋 Hi, I’m Ollie!
 - 👀 I’m interested in sport, coding and design
-- 🌱 I can currently code in HTML, CSS, Node.js, React.js Java and Discord.js 
+- 🌱 I can currently code in HTML, CSS, JavaScript and Java.
 - 📫 How to reach me I have an epic discord server! (https://cup.corasite.repl.it/discord)
-
+- 


### PR DESCRIPTION
Dear OSX,

I am back! I thought I'd help you a little by contributing to your GitHub repository!

In line 3 programming languages and libraries are mixed up. Node.js, ReactJS and Discord.js are not programming languages (HTML arguably is, so I left that as is), they all use JavaScript, this PR corrects that.

I hope you have a nice day, and I'd like to see this PR merged soon!

Sincerly,
RandomKid